### PR TITLE
support Cri 2.12+, lock gems, (c) 2019, v0.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017, Salesforce.com, Inc.
+Copyright (c) 2019, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ end
 
 ## License
 
->Copyright (c) 2017, Salesforce.com, Inc.
+>Copyright (c) 2019, Salesforce.com, Inc.
 >All rights reserved.
 >
 >Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/bin/flo
+++ b/bin/flo
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/flo.gemspec
+++ b/flo.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gpgme'
   spec.add_dependency 'cri'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-proveit'

--- a/lib/flo.rb
+++ b/lib/flo.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/cli.rb
+++ b/lib/flo/cli.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -53,7 +53,7 @@ module Flo
           description(cmd[:description])
 
           run do |opts, arguments, command|
-            flo_runner.execute(command.name, arguments.dup.push(opts))
+            flo_runner.execute(command.name, arguments.to_a.push(opts))
           end
         end
       end

--- a/lib/flo/command.rb
+++ b/lib/flo/command.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/command_collection.rb
+++ b/lib/flo/command_collection.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/config.rb
+++ b/lib/flo/config.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/cred_store/creds.rb
+++ b/lib/flo/cred_store/creds.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/cred_store/pw_protected_store.rb
+++ b/lib/flo/cred_store/pw_protected_store.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/cred_store/yaml_store.rb
+++ b/lib/flo/cred_store/yaml_store.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/error.rb
+++ b/lib/flo/error.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/provider/base.rb
+++ b/lib/flo/provider/base.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/provider/developer.rb
+++ b/lib/flo/provider/developer.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/runner.rb
+++ b/lib/flo/runner.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/state.rb
+++ b/lib/flo/state.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/task.rb
+++ b/lib/flo/task.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/lib/flo/version.rb
+++ b/lib/flo/version.rb
@@ -1,8 +1,8 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 
 module Flo
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/test/fixtures/basic_setup.rb
+++ b/test/fixtures/basic_setup.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/fixtures/one_config_call.rb
+++ b/test/fixtures/one_config_call.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/cli_test.rb
+++ b/test/flo/cli_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/command_collection_test.rb
+++ b/test/flo/command_collection_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/command_test.rb
+++ b/test/flo/command_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/config_test.rb
+++ b/test/flo/config_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/cred_store/creds_test.rb
+++ b/test/flo/cred_store/creds_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/cred_store/pw_protected_store_test.rb
+++ b/test/flo/cred_store/pw_protected_store_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/cred_store/yaml_store_test.rb
+++ b/test/flo/cred_store/yaml_store_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/flo_test.rb
+++ b/test/flo/flo_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/provider/base_test.rb
+++ b/test/flo/provider/base_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/runner_integration_test.rb
+++ b/test/flo/runner_integration_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/runner_test.rb
+++ b/test/flo/runner_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/state_test.rb
+++ b/test/flo/state_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/flo/task_test.rb
+++ b/test/flo/task_test.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright © 2017, Salesforce.com, Inc.
+# Copyright © 2019, Salesforce.com, Inc.
 # All Rights Reserved.
 # Licensed under the BSD 3-Clause license.
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
* `Flo::Cli#generate_commands`: gain compatibility with Cri v2.12+ by
  not attempting to modify the `Cri::ArgumentList`'s frozen internal
  `@arguments_array` object. Use `#to_a` to obtain a new array (not
  frozen) that can be pushed to.
* Bump all copyright dates to `2019`
* Bump version to `0.0.5`
 * `flo.gemspec`: remove Bundler gem version lock